### PR TITLE
Add post on patents and production AI

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -82,7 +82,7 @@ You need to [create a personal access token](https://docs.github.com/en/authenti
 
 We implemented support for [Prettier code formatting](https://prettier.io/) in [#2048](https://github.com/alshedivat/al-folio/pull/2048). It basically ensures that your code is [well formatted](https://prettier.io/docs/en/). If you want to ensure your code is compliant with `Prettier`, you have a few options:
 
-- if you are running locally with `Docker` and using [development containers](https://github.com/alshedivat/al-folio/blob/main/INSTALL.md#local-setup-with-development-containers), `Prettier` is already included
+- if you are running locally with `Docker` and using [development containers](INSTALL.md#local-setup-with-development-containers), `Prettier` is already included
 - if you don't use `Docker`, it is simple to integrate it with your preferred IDE using an [extension](https://prettier.io/docs/en/editors)
 - if you want to run it manually, you can follow the first 2 steps in [this tutorial](https://george-gca.github.io/blog/2023/slidev_for_non_web_devs/) (`Installing node version manager (nvm)` and `Installing Node (latest version)`), then, install it using `npm install prettier` inside the project directory, or install it globally on your computer using `npm install -g prettier`. To run `Prettier` on your current directory use `npx prettier . --write`.
 
@@ -150,9 +150,9 @@ Currently we have the following workflows:
 - `deploy-image.yml`: deploys a new docker image with the latest changes to Docker Hub
 - `deploy.yml`: deploys the website to GitHub Pages
 - `docker-slim.yml`: deploys a smaller version of the docker image to Docker Hub with the [docker-slim-action](https://github.com/kitabisa/docker-slim-action)
-- `lighthouse-badger.yml`: runs a [lighthouse](https://github.com/GoogleChrome/lighthouse) test for your site with the [lighthouse-badger-action](https://github.com/MyActionWay/lighthouse-badger-action), saving the results in the repository for easy inspecting, as can be seen [here](https://github.com/alshedivat/al-folio?tab=readme-ov-file#lighthouse-pagespeed-insights). For more information on how to enable this workflow, check our [FAQ question about it](https://github.com/alshedivat/al-folio/blob/main/FAQ.md#when-i-manually-run-the-lighthouse-badger-workflow-it-fails-with-error-input-required-and-not-supplied-token-how-do-i-fix-that)
+- `lighthouse-badger.yml`: runs a [lighthouse](https://github.com/GoogleChrome/lighthouse) test for your site with the [lighthouse-badger-action](https://github.com/MyActionWay/lighthouse-badger-action), saving the results in the repository for easy inspecting, as can be seen [here](https://github.com/alshedivat/al-folio?tab=readme-ov-file#lighthouse-pagespeed-insights). For more information on how to enable this workflow, check our [FAQ question about it](#when-i-manually-run-the-lighthouse-badger-workflow-it-fails-with-error-input-required-and-not-supplied-token-how-do-i-fix-that)
 - `prettier-comment-on-pr.yml`: not working. For now, this action is disabled. It was supposed to run prettier on the PRs and comment on them with the changes needed. For more information, check [issue 2115](https://github.com/alshedivat/al-folio/issues/2115)
-- `prettier.yml`: runs [prettier](https://prettier.io/) on the code to ensure it is well formatted. For more information, check our [FAQ question about it](https://github.com/alshedivat/al-folio/blob/main/FAQ.md#my-code-runs-fine-locally-but-when-i-create-a-commit-and-submit-it-it-fails-with-prettier-code-formatter-workflow-run-failed-for-main-branch-how-do-i-fix-that)
+- `prettier.yml`: runs [prettier](https://prettier.io/) on the code to ensure it is well formatted. For more information, check our [FAQ question about it](#my-code-runs-fine-locally-but-when-i-create-a-commit-and-submit-it-it-fails-with-prettier-code-formatter-workflow-run-failed-for-main-branch-how-do-i-fix-that)
 
 ---
 

--- a/_posts/2026-06-09-patents-are-not-the-main-work.md
+++ b/_posts/2026-06-09-patents-are-not-the-main-work.md
@@ -22,6 +22,7 @@ That part is nice, of course.
 But patenting ideas is far from the main work of an AI engineer.
 
 The main work is less shiny:
+
 - choosing the right problem
 - talking to users before building too much
 - killing the first idea when it is wrong
@@ -36,3 +37,5 @@ We'll talk about the agentic system I worked on at Intuit, why the original chat
 Join live if you want to ask questions in real time:
 
 [https://luma.com/6c089dac](https://luma.com/6c089dac)
+
+P.S. Patents are not a default part of AI/ML/DS work. A lot of excellent people in the field never write one. I was lucky to learn how the process works a few years ago from very good teachers, and to work in places where turning practical ideas into patent applications was supported. It is a separate skill, and I am still grateful someone taught me.

--- a/_posts/2026-06-09-patents-are-not-the-main-work.md
+++ b/_posts/2026-06-09-patents-are-not-the-main-work.md
@@ -1,0 +1,38 @@
+---
+layout: post
+title: "Patents Are Not the Main Work"
+date: 2026-06-09 12:00:00+0100
+description: "Two more patent applications are issuing, and a note on what AI engineering looks like in production."
+tags: [ai-engineering, patents, llm-agents, production-ml]
+categories: career
+---
+
+Last week I got two emails from the patent team: two more of my patent applications are going to issue as US patents.
+
+This will bring me to 7 issued patents, with roughly a dozen more still pending review.
+
+The two new ones are around document understanding and LLM explainability. I am intentionally not putting the full titles here, because the titles are long and, honestly, patents are not the main point.
+
+A patent sounds like a clean invention story.
+
+In practice, at least in applied AI, it is usually messier than that. You run into a specific production problem, try a few things that do not work, combine some existing ideas in a way that fits the domain, and only later realise there may be something novel enough to protect.
+
+That part is nice, of course.
+
+But patenting ideas is far from the main work of an AI engineer.
+
+The main work is less shiny:
+- choosing the right problem
+- talking to users before building too much
+- killing the first idea when it is wrong
+- translating ML metrics into business outcomes
+- making the system reliable enough to run without you watching it
+- keeping costs under control after the demo works
+
+On June 15, I'll be joining DataTalks.Club live to talk about this side of AI engineering: how to build AI that actually ships in production.
+
+We'll talk about the agentic system I worked on at Intuit, why the original chatbot idea did not survive, how evaluation and business metrics shaped the project, and why the model is rarely the win.
+
+Join live if you want to ask questions in real time:
+
+[https://luma.com/6c089dac](https://luma.com/6c089dac)


### PR DESCRIPTION
## Summary
- Adds a new blog post using the recent patent issuance as a hook for the DataTalks.Club production AI podcast.
- Keeps full patent titles out of the post and refers only to document understanding and LLM explainability.
- Makes the Luma event URL a clickable external link.

## Validation
- `docker compose run --rm jekyll bundle exec jekyll build` passed.
- Local render checked at `http://127.0.0.1:8080/blog/` and `/blog/2026/patents-are-not-the-main-work/`.
- Playwright CLI screenshots captured for blog index, desktop post viewport, and mobile post viewport.
- Rendered HTML confirmed the post title, date, six bullets, clickable Luma link, and absence of full patent titles.

## Notes
- Native `bundle exec jekyll build` was not usable because system Ruby is 2.6 and the locked Bundler requires Ruby >= 3.1; Docker build path was used instead.
- In-app Browser was unavailable (`iab` not exposed), so validation used local HTTP checks plus Playwright CLI screenshots.
