### PR TITLE
[codex] Add post on AI engineering podcast

### DIFF
--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -16,7 +16,7 @@
   </head>
 
   <!-- Body -->
-  <body class="{% if site.navbar_fixed %}fixed-top-nav{% endif %} {% unless site.footer_fixed %}sticky-bottom-footer{% endunless %}">
+  <body class="{% if site.navbar_fixed %}fixed-top-nav{% endif %} {% if site.footer_fixed %}fixed-bottom-footer{% else %}sticky-bottom-footer{% endif %}">
     <!-- Header -->
     {% include header.liquid %}
 

--- a/_posts/2026-06-16-ai-engineering-podcast.md
+++ b/_posts/2026-06-16-ai-engineering-podcast.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: Talking About AI Engineering in Production
+date: 2026-06-16 09:00:00+0100
+description: Notes from my DataTalksClub conversation on production AI engineering, evaluation, routing, token costs, and when to stop an AI pilot.
+tags: [AI, LLMs, production, evaluation, talks]
+categories: talks
+---
+
+The recording of my conversation with DataTalksClub is now live:
+[How to Build AI that actually Ships in Production - Aleksandr Kim](https://www.youtube.com/watch?v=PosCx_4fwt0).
+
+A good AI demo can be dangerously convincing.
+
+The first version often looks useful. A model reads something, writes something, maybe answers a few test questions well. From the dev side, it can feel like the hard part is done.
+
+Then production starts asking boring questions.
+
+Can we measure whether the answer was actually useful? What happens when the data access or infrastructure is not ready? Which model should handle which task? How much are we spending on tokens? Who notices when the system quietly becomes worse?
+
+That was the main thread of the conversation. We went from a BERT customer-support system at Kaspersky, where the real win was reframing 200 categories into the 20-30 that were actionable, to an Intuit agentic insights project that started as a chatbot and became automated Slack reporting after customer interviews.
+
+We also talked about evaluation, routing, caching, token cost, and the harder skill of knowing when to abandon a project because the bottleneck is not the model.
+
+Different technology, same old pattern: the model is rarely the whole product. The useful work is usually around it. Define the behavior. Connect it to a business outcome. Build the checks. Watch the cost. Be honest when the infrastructure is not ready.
+
+That is the part of AI engineering I find most interesting: turning an impressive prototype into a workflow that behaves predictably when real users, real data, and real constraints show up.

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -493,6 +493,20 @@ footer.fixed-bottom {
   }
 }
 
+body.fixed-bottom-footer {
+  padding-bottom: 3.5rem;
+}
+
+@media only screen and (max-width: 576px) {
+  footer.fixed-bottom {
+    position: static;
+  }
+
+  body.fixed-bottom-footer {
+    padding-bottom: 0;
+  }
+}
+
 footer.sticky-bottom {
   border-top: 1px solid var(--global-divider-color);
   padding-top: 40px;


### PR DESCRIPTION
## Summary

- Add a short portfolio post about the DataTalksClub AI engineering podcast appearance.
- Reword the post around the factual prepared topics: BERT support automation, chatbot-to-Slack reporting, evaluation, routing, caching, token cost, and knowing when to abandon blocked AI pilots.
- Add a small footer layout adjustment so fixed footers do not obscure mobile blog content.

## Validation

- Rebased branch on latest `origin/main`.
- `npx prettier _posts/2026-06-16-ai-engineering-podcast.md _layouts/default.liquid _sass/_base.scss --check`
- `docker compose run --rm jekyll bundle exec jekyll build`
- Rendered QA on `http://127.0.0.1:8080/blog/` and `/blog/2026/ai-engineering-podcast/` for desktop/mobile, YouTube link presence, and console errors.

## Notes

Local build still emits existing theme Sass/Rails deprecation warnings, but the build succeeds.